### PR TITLE
LDAP Improvements

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -41,6 +41,9 @@ Contents:
     <Directory "C:\I, Librarian\library">
         Order allow,deny
     </Directory>
+    <Files "C:\I, Librarian\ilibrarian.ini">
+        Order allow,deny
+    </Files>
 
     You may change "C:\I, Librarian" to any directory where you want to have
     I, Librarian, including an external drive. For a groupware use, you need to
@@ -100,6 +103,9 @@ Contents:
     <Directory "/var/www/html/librarian/library">
         Order allow,deny
     </Directory>
+    <Files "/var/www/html/librarian/ilibrarian.ini">
+        Order allow,deny
+    </Files>
 
     To enable access from the Network, you need to allow access to more
     IP numbers or domain names. Just add more Allow from directives (Allow from
@@ -128,6 +134,9 @@ Contents:
     <Directory /Users/Yourusername/Sites/librarian/library>
         Order allow,deny
     </Directory>
+    <Files "/Users/Yourusername/Sites/librarian/ilibrarian.ini">
+        Order allow,deny
+    </Files>
 
     Don't forget to change "yourusername" to your actual user name. You can find
     out your user name by typing whoami in Terminal.

--- a/ilibrarian.ini
+++ b/ilibrarian.ini
@@ -121,6 +121,12 @@ ldap_rdn[] = "ou=users"
 
 ldap_rdn[] = "ou=groups"
 
+; User group common name
+; If not defined, all users under the search base are eligible to use this
+; installation of I, Librarian
+
+;ldap_user_cn = "cn=users"
+
 ; Admin group common name
 
 ldap_admin_cn = "cn=Domain Admins"

--- a/ilibrarian.ini
+++ b/ilibrarian.ini
@@ -101,22 +101,30 @@ ldap_port = 389
 
 ldap_basedn = "dc=testathon,dc=net"
 
+; Proxy user to use for username lookups (without base DN)
+
+ldap_binduser_rdn = "cn=stuart,ou=users"
+
+; Password for proxy user
+
+ldap_binduser_pw = 'stuart'
+
 ; User common name prefix
 
-ldap_cn = "cn="
+ldap_cn = "cn"
 
 ; Change to reflect users relative dn
 
 ldap_rdn[] = "ou=users"
 
-; Change to reflect group relative dn (optional)
+; Change to reflect group relative dn
 
 ldap_rdn[] = "ou=groups"
 
-; Admin group common name  (optional)
+; Admin group common name
 
 ldap_admin_cn = "cn=Domain Admins"
 
 ; Authorization filter prefix  (optional)
 
-ldap_filter = "memberUid="
+ldap_filter = "member"

--- a/ilibrarian.ini
+++ b/ilibrarian.ini
@@ -111,27 +111,27 @@ ldap_binduser_rdn = "cn=stuart,ou=users"
 
 ldap_binduser_pw = 'stuart'
 
-; User common name prefix
+; Attribute to use for username lookups
 
-ldap_cn = "cn"
+ldap_username_attr = "cn"
 
 ; User relative search base (without base DN)
 
-ldap_rdn[] = "ou=users"
+ldap_user_rdn = "ou=users"
 
 ; Group relative search base (without base DN)
 
-ldap_rdn[] = "ou=groups"
+ldap_group_rdn = "ou=groups"
 
 ; User group common name
 ; If not defined, all users under the search base are eligible to use this
 ; installation of I, Librarian
 
-;ldap_user_cn = "cn=users"
+;ldap_usergroup_cn = "cn=users"
 
 ; Admin group common name
 
-ldap_admin_cn = "cn=Domain Admins"
+ldap_admingroup_cn = "cn=Domain Admins"
 
 ; Authorization filter prefix
 ; If you want to do recursive searches with LDAP servers that

--- a/ilibrarian.ini
+++ b/ilibrarian.ini
@@ -78,10 +78,12 @@ left_window_background_color = "F5F5F6"
 ; Enter your LDAP server settings below. The current settings
 ; are for a free dummy LDAP server at:
 ; http://blog.stuartlewis.com/2008/07/07/test-ldap-service/
-; Use stuart:stuart credentials to test its functionality.
-; LDAP access does not work from behind a PROXY server.
+; Use stuart:stuart, john:john, or carol:carol credentials to
+; test its functionality.
+; LDAP access does not work from behind a proxy server.
 
-; Activate or not the LDAP login true/false
+; Activate login via LDAP
+; Caution: Disables local login
 
 ldap_active = false
 
@@ -89,15 +91,15 @@ ldap_active = false
 
 ldap_version = 3
 
-; Change to ip address of ldap server
+; LDAP server hostname
 
 ldap_server = "ldap://ldap.testathon.net"
 
-; Change to LDAP server port
+; LDAP server port
 
 ldap_port = 389
 
-; Change to reflect the base distinguished name
+; Base distinguished name (DN)
 
 ldap_basedn = "dc=testathon,dc=net"
 
@@ -113,11 +115,11 @@ ldap_binduser_pw = 'stuart'
 
 ldap_cn = "cn"
 
-; Change to reflect users relative dn
+; User relative search base (without base DN)
 
 ldap_rdn[] = "ou=users"
 
-; Change to reflect group relative dn
+; Group relative search base (without base DN)
 
 ldap_rdn[] = "ou=groups"
 
@@ -131,6 +133,10 @@ ldap_rdn[] = "ou=groups"
 
 ldap_admin_cn = "cn=Domain Admins"
 
-; Authorization filter prefix  (optional)
+; Authorization filter prefix
+; If you want to do recursive searches with LDAP servers that
+; support it (e.g., MS Active Directory), use t he correct
+; matching rule:
+; ldap_filter = 'member:1.2.840.113556.1.4.1941'
 
 ldap_filter = "member"

--- a/index2.php
+++ b/index2.php
@@ -86,6 +86,8 @@ $ldap_version = $ini_array['ldap_version'];
 $ldap_server = $ini_array['ldap_server'];
 $ldap_port = $ini_array['ldap_port'];
 $ldap_basedn = $ini_array['ldap_basedn'];
+$ldap_binduser_rdn = $ini_array['ldap_binduser_rdn'];
+$ldap_binduser_pw = $ini_array['ldap_binduser_pw'];
 $ldap_rdn = $ini_array['ldap_rdn'];
 $ldap_cn = $ini_array['ldap_cn'];
 $ldap_admin_cn = $ini_array['ldap_admin_cn'];
@@ -311,20 +313,42 @@ if (isset($_POST['form']) && $_POST['form'] == 'signin' && !empty($_POST['user']
     /* IS THE USER AN LDAP USER? */
     if ($ldap_active) {
 
+        /* CONNECT */
         if (!$ldap_connect = ldap_connect($ldap_server, $ldap_port))
             die("Could not connect to LDAP server");
 
         if (!ldap_set_option($ldap_connect, LDAP_OPT_PROTOCOL_VERSION, $ldap_version))
             die("Failed to set version to protocol $ldap_version");
 
-        $ldap_dn = $ldap_cn . $username . ',' . $ldap_rdn[0] . ',' . $ldap_basedn;
+        /* BIND */
+        $ldap_binduser_dn = $ldap_binduser_rdn . ',' . $ldap_basedn;
+        if (!$ldap_bind = @ldap_bind($ldap_connect, $ldap_binduser_dn, $ldap_binduser_pw))
+            die("Failed to bind as proxy user.");
+
+        /* LOOKUP */
+        /* Users matching the following criteria are eligible:
+         * - must be a person object of class user or iNetOrgPerson
+         * - username must match the CN attribute specified in INI file
+         * - must be situated below the base search DN
+         */
+
+        $ldap_filter_string = '(&(|(objectClass=user)(objectClass=iNetOrgPerson))' .
+            '(' . $ldap_cn . '=' . $username . '))';
+
+        if (!$ldap_sr = @ldap_search($ldap_connect, $ldap_rdn[0] . ',' . $ldap_basedn, $ldap_filter_string, array($ldap_cn)))
+            die("Bad username or password.");
+        $ldap_num_entries = ldap_count_entries($ldap_connect, $ldap_sr);
+        if ($ldap_num_entries != 1)
+            die("Bad username or password.");
+        $ldap_user_sr = ldap_first_entry($ldap_connect, $ldap_sr);
+        $ldap_user_dn = ldap_get_dn($ldap_connect, $ldap_user_sr);
 
         /* AUTHENTICATE */
-        if ($ldap_bind = @ldap_bind($ldap_connect, $ldap_dn, $password)) {
+        if ($ldap_bind = @ldap_bind($ldap_connect, $ldap_user_dn, $password)) {
 
             /* AUTHORIZE ADMIN */
-            $ldap_dn = $ldap_admin_cn . ',' . $ldap_rdn[1] . ',' . $ldap_basedn;
-            $ldap_sr = @ldap_read($ldap_connect, $ldap_dn, '(' . $ldap_filter . $username . ')', array('memberUid'));
+            $ldap_admin_group_dn = $ldap_admin_cn . ',' . $ldap_rdn[1] . ',' . $ldap_basedn;
+            $ldap_sr = @ldap_read($ldap_connect, $ldap_admin_group_dn, '(' . $ldap_filter . '=' . $ldap_user_dn . ')', array('member'));
             $ldap_info_group = @ldap_get_entries($ldap_connect, $ldap_sr);
 
             $permissions = 'U';

--- a/m/index2.php
+++ b/m/index2.php
@@ -44,6 +44,7 @@ $ldap_binduser_rdn = $ini_array['ldap_binduser_rdn'];
 $ldap_binduser_pw = $ini_array['ldap_binduser_pw'];
 $ldap_rdn = $ini_array['ldap_rdn'];
 $ldap_cn = $ini_array['ldap_cn'];
+$ldap_user_cn = $ini_array['ldap_user_cn'];
 $ldap_admin_cn = $ini_array['ldap_admin_cn'];
 $ldap_filter = $ini_array['ldap_filter'];
 if (!extension_loaded('ldap'))
@@ -162,14 +163,30 @@ if (isset($_POST['form']) && $_POST['form'] == 'signin' && !empty($_POST['user']
         /* AUTHENTICATE */
         if ($ldap_bind = @ldap_bind($ldap_connect, $ldap_user_dn, $password)) {
 
-            /* AUTHORIZE ADMIN */
+            /* AUTHORIZE */
+            /* Check if user is in admin group */
             $ldap_admin_group_dn = $ldap_admin_cn . ',' . $ldap_rdn[1] . ',' . $ldap_basedn;
             $ldap_sr = @ldap_read($ldap_connect, $ldap_admin_group_dn, '(' . $ldap_filter . '=' . $ldap_user_dn . ')', array('member'));
             $ldap_info_group = @ldap_get_entries($ldap_connect, $ldap_sr);
 
-            $permissions = 'U';
-            if ($ldap_info_group['count'] > 0)
+            if ($ldap_info_group['count'] > 0) {
                 $permissions = 'A';
+            } else {
+                /* If we don't have a ldap_user_cn setting, assume all
+                 * users under the search base are eligible */
+                if (is_null($ldap_user_cn)) {
+                    $permissions = 'U';
+                } else {
+                    $ldap_user_group_dn = $ldap_user_cn . ',' . $ldap_rdn[1] . ',' . $ldap_basedn;
+                    $ldap_sr = @ldap_read($ldap_connect, $ldap_user_group_dn, '(' . $ldap_filter . '=' . $user_dn . ')', array('member'));
+                    $ldap_info_group = @ldap_get_entries($ldap_connect, $ldap_sr);
+                    if ($ldap_info_group['count'] > 0) {
+                        $permissions = 'U';
+                    } else {
+                        die("Bad username or password.");
+                    }
+                }
+            }
 
             $dbHandle->beginTransaction();
 

--- a/m/index2.php
+++ b/m/index2.php
@@ -42,10 +42,11 @@ $ldap_port = $ini_array['ldap_port'];
 $ldap_basedn = $ini_array['ldap_basedn'];
 $ldap_binduser_rdn = $ini_array['ldap_binduser_rdn'];
 $ldap_binduser_pw = $ini_array['ldap_binduser_pw'];
-$ldap_rdn = $ini_array['ldap_rdn'];
-$ldap_cn = $ini_array['ldap_cn'];
-$ldap_user_cn = $ini_array['ldap_user_cn'];
-$ldap_admin_cn = $ini_array['ldap_admin_cn'];
+$ldap_user_rdn = $ini_array['ldap_user_rdn'];
+$ldap_group_rdn = $ini_array['ldap_group_rdn'];
+$ldap_username_attr = $ini_array['ldap_username_attr'];
+$ldap_usergroup_cn = $ini_array['ldap_usergroup_cn'];
+$ldap_admingroup_cn = $ini_array['ldap_admingroup_cn'];
 $ldap_filter = $ini_array['ldap_filter'];
 if (!extension_loaded('ldap'))
     $ldap_active = false;
@@ -150,9 +151,9 @@ if (isset($_POST['form']) && $_POST['form'] == 'signin' && !empty($_POST['user']
          */
 
         $ldap_filter_string = '(&(|(objectClass=user)(objectClass=iNetOrgPerson))' .
-            '(' . $ldap_cn . '=' . $username . '))';
+            '(' . $ldap_username_attr . '=' . $username . '))';
 
-        if (!$ldap_sr = @ldap_search($ldap_connect, $ldap_rdn[0] . ',' . $ldap_basedn, $ldap_filter_string, array($ldap_cn)))
+        if (!$ldap_sr = @ldap_search($ldap_connect, $ldap_user_rdn . ',' . $ldap_basedn, $ldap_filter_string, array($ldap_username_attr)))
             die("Bad username or password.");
         $ldap_num_entries = ldap_count_entries($ldap_connect, $ldap_sr);
         if ($ldap_num_entries != 1)
@@ -165,19 +166,19 @@ if (isset($_POST['form']) && $_POST['form'] == 'signin' && !empty($_POST['user']
 
             /* AUTHORIZE */
             /* Check if user is in admin group */
-            $ldap_admin_group_dn = $ldap_admin_cn . ',' . $ldap_rdn[1] . ',' . $ldap_basedn;
+            $ldap_admin_group_dn = $ldap_admingroup_cn . ',' . $ldap_group_rdn . ',' . $ldap_basedn;
             $ldap_sr = @ldap_read($ldap_connect, $ldap_admin_group_dn, '(' . $ldap_filter . '=' . $ldap_user_dn . ')', array('member'));
             $ldap_info_group = @ldap_get_entries($ldap_connect, $ldap_sr);
 
             if ($ldap_info_group['count'] > 0) {
                 $permissions = 'A';
             } else {
-                /* If we don't have a ldap_user_cn setting, assume all
+                /* If we don't have a ldap_usergroup_cn setting, assume all
                  * users under the search base are eligible */
-                if (is_null($ldap_user_cn)) {
+                if (is_null($ldap_usergroup_cn)) {
                     $permissions = 'U';
                 } else {
-                    $ldap_user_group_dn = $ldap_user_cn . ',' . $ldap_rdn[1] . ',' . $ldap_basedn;
+                    $ldap_user_group_dn = $ldap_usergroup_cn . ',' . $ldap_group_rdn . ',' . $ldap_basedn;
                     $ldap_sr = @ldap_read($ldap_connect, $ldap_user_group_dn, '(' . $ldap_filter . '=' . $user_dn . ')', array('member'));
                     $ldap_info_group = @ldap_get_entries($ldap_connect, $ldap_sr);
                     if ($ldap_info_group['count'] > 0) {


### PR DESCRIPTION
This PR refactors the LDAP authentication mechanism. The new implementation was tested with both the test LDAP server at ldap.testathon.net and our local Active Directory LDAP server at MLU Halle-Wittenberg.

The new implementation provides the following benefits:

- It uses a proxy user to do username and DN lookups. The previous implementation did not allow for users in nested OUs to log in. (Anonymous LDAP binds should work as well, just leave `ldap_binduser_rdn` and `ldap_binduser_pw` as empty strings for now.)
- It (optionally) allows to restrict logins to members of an LDAP group. If recursive membership checking is needed, this can be done with a custom `ldap_filter` setting, an example of which is provided in `ilibrarian.ini`.

There is also one disadvantage I can see:
- For now, the bind user DN and password are stored as plaintext in `ilibrarian.ini`. Therefore, the example webserver configuration in `README.txt` has been updated to deny access to this file by default. **If this PR is merged in, the documentation on the homepage should also be updated accordingly.**

Things I would like to address in the future:
- Commenting out `ldap_binduser_rdn` and/or `ldap_binduser_pw` should perform the correct form of anonymous bind to LDAP implementations that support it.
- Address I, Librarian's behavior where the first user to populate the database is always given admin permissions, even if she is not a member of the I, Librarian LDAP admin group.

If there are any things I should change or improve, just say so. Cheers! :)