### PR TITLE
Make it easier to view things in-browser

### DIFF
--- a/attachment.php
+++ b/attachment.php
@@ -43,7 +43,11 @@ if (!empty($file) && is_file($path . DIRECTORY_SEPARATOR . $file)) {
     header('Last-Modified: '.gmdate(DATE_RFC1123,filemtime($path . DIRECTORY_SEPARATOR . $file)));
 
     header("Content-Type: " . $type);
-    header("Content-Disposition: " . $mode . "; filename=\"$filename\"");
+
+    if ($mode != 'inline'){
+        header("Content-Disposition: " . $mode . "; filename=\"$filename\"");
+    }
+    
     header('Content-Length: ' . filesize($path . DIRECTORY_SEPARATOR . $file));
     ob_clean();
     flush();

--- a/file_top.php
+++ b/file_top.php
@@ -348,7 +348,8 @@ if (isset($_GET['file'])) {
             $files_to_display = glob('library/supplement/' . $integer . '*');
             if (is_array($files_to_display)) {
                 foreach ($files_to_display as $supplementary_file) {
-                    $url_filenames[] = '<li><a href="' . htmlspecialchars('attachment.php?attachment=' . basename($supplementary_file)) . '">' . substr(basename($supplementary_file), 5) . '</a>';
+                    $url_filenames[] = '<li><a href="' . htmlspecialchars('attachment.php?mode=inline&attachment=' . basename($supplementary_file)) . '">' . substr(basename($supplementary_file), 5) . '</a>'
+                    . ' <a href="' . htmlspecialchars('attachment.php?attachment=' . basename($supplementary_file)) . '"> (download)</a>';
                 }
                 $url_filename = join('<br>', $url_filenames);
             }

--- a/files.php
+++ b/files.php
@@ -171,7 +171,7 @@ if (isset($_SESSION['auth'])) {
                                             print '<i class="fa fa-film video" style="cursor:pointer" title="Click to play"></i> ';
                                             print '<a href="' . htmlspecialchars('attachment.php?attachment=' . basename($supplementary_file)) . '">';
                                         } else {
-                                            print '<i class="fa fa-file-o" style="padding:0.15em"></i> ';
+                                            print '<a href="' . htmlspecialchars('attachment.php?mode=inline&attachment=' . basename($supplementary_file)) . '"><i class="fa fa-file-o" style="padding:0.15em"></i></a> ';
                                             print '<a href="' . htmlspecialchars('attachment.php?attachment=' . basename($supplementary_file)) . '">';
                                         }
 

--- a/items.php
+++ b/items.php
@@ -188,17 +188,17 @@ if (empty($export_files))
         <div id="items-notes-menu" style="display:none;width:60px;position:fixed;top:0;left:0;text-align: center;padding:5px 2px;z-index: 2000;cursor: pointer">
             <i class="fa fa-external-link"></i><br>Edit
         </div>
-        <div id="items-pdf-menu" class="ui-state-highlight" style="display:none;position:fixed;top:0;left:0;width:195px;z-index: 2001;padding:0;border:0">
-            
+        <div id="items-pdf-menu" class="ui-state-highlight" style="display:none;position:fixed;top:0;left:0;width:197px;z-index: 2001;padding:0;border:0">
+
             <div id="items-pdf-menu-a1" style="width:60px;text-align: center;padding:5px 2px;cursor: pointer;float:left;margin-right: 1px" data-mode="external">
                 <i class="fa fa-external-link"></i><br>
                 Browser
             </div>
 
-            <div id="items-pdf-menu-a2" style="width:60px;text-align: center;padding:5px 2px;cursor: pointer;float:left;margin-right: 1px" data-mode="internal">
+            <div id="items-pdf-menu-a2" style="width:62px;text-align: center;padding:5px 2px;cursor: pointer;float:left;margin-right: 1px" data-mode="internal">
                 <i class="fa fa-external-link"></i><br>
-                i, Librarian
-            </div>            
+                I, Librarian
+            </div>
 
             <div id="items-pdf-menu-b" style="width:60px;text-align: center;padding:5px 2px;cursor: pointer;float:right">
                 <i class="fa fa-download"></i><br>Download

--- a/items.php
+++ b/items.php
@@ -188,21 +188,20 @@ if (empty($export_files))
         <div id="items-notes-menu" style="display:none;width:60px;position:fixed;top:0;left:0;text-align: center;padding:5px 2px;z-index: 2000;cursor: pointer">
             <i class="fa fa-external-link"></i><br>Edit
         </div>
-        <div id="items-pdf-menu" class="ui-state-highlight" style="display:none;position:fixed;top:0;left:0;width:129px;z-index: 2001;padding:0;border:0">
-            <div id="items-pdf-menu-a" style="width:60px;text-align: center;padding:5px 2px;cursor: pointer;float:left;margin-right: 1px"
-                 <?php
-                if (isset($_SESSION['pdfviewer']) && $_SESSION['pdfviewer'] == 'external')
-                    echo 'data-mode="external"';
-
-                if (!isset($_SESSION['pdfviewer']) || (isset($_SESSION['pdfviewer']) && $_SESSION['pdfviewer'] == 'internal'))
-                    echo 'data-mode="internal"';
-                ?>
-                 >
+        <div id="items-pdf-menu" class="ui-state-highlight" style="display:none;position:fixed;top:0;left:0;width:195px;z-index: 2001;padding:0;border:0">
+            
+            <div id="items-pdf-menu-a1" style="width:60px;text-align: center;padding:5px 2px;cursor: pointer;float:left;margin-right: 1px" data-mode="external">
                 <i class="fa fa-external-link"></i><br>
-                Window
+                Browser
             </div>
+
+            <div id="items-pdf-menu-a2" style="width:60px;text-align: center;padding:5px 2px;cursor: pointer;float:left;margin-right: 1px" data-mode="internal">
+                <i class="fa fa-external-link"></i><br>
+                i, Librarian
+            </div>            
+
             <div id="items-pdf-menu-b" style="width:60px;text-align: center;padding:5px 2px;cursor: pointer;float:right">
-                <i class="fa fa-download"></i><br>External
+                <i class="fa fa-download"></i><br>Download
             </div>
         </div>
         <div id="file-panel" style="width:auto;height:48%;border-top:1px solid #c6c8cc;overflow:auto">

--- a/js/javascript.js
+++ b/js/javascript.js
@@ -1884,14 +1884,20 @@ var items = {
                 edit.init();
             });
         });
-        $('#items-pdf-menu-a').click(function() {
+
+        $('#items-pdf-menu-a1').click(function() {
             var filename = $('#items-left').find('.clicked').data('file'), title = $('#items-left').find('.clicked').text();
             var mode = $(this).data('mode');
-            if (mode === 'internal')
-                window.open('viewpdf.php?file=' + filename + '&title=' + title);
-            if (mode === 'external')
-                window.open('downloadpdf.php?file=' + filename + '#pagemode=none&scrollbar=1&navpanes=0&toolbar=1&statusbar=0&page=1&view=FitH,0');
+            window.open('downloadpdf.php?file=' + filename + '#pagemode=none&scrollbar=1&navpanes=0&toolbar=1&statusbar=0&page=1&view=FitH,0');
         });
+
+        $('#items-pdf-menu-a2').click(function() {
+            var filename = $('#items-left').find('.clicked').data('file'), title = $('#items-left').find('.clicked').text();
+            var mode = $(this).data('mode');
+            window.open('viewpdf.php?file=' + filename + '&title=' + title);
+        });
+
+
         $('#items-pdf-menu-b').click(function() {
             var filename = $('#items-left').find('.clicked').data('file');
             window.location.assign('downloadpdf.php?mode=download&file=' + filename);

--- a/style.php
+++ b/style.php
@@ -175,7 +175,8 @@ a.topindex_clicked {
 #items-menu > div:focus,
 #items-menu > div.tabclicked,
 #items-notes-menu,
-#items-pdf-menu-a,
+#items-pdf-menu-a1,
+#items-pdf-menu-a2,
 #items-pdf-menu-b {
     background-color: #" . $top_window_background_color . ";
     color: #" . $top_window_color . ";
@@ -183,7 +184,8 @@ a.topindex_clicked {
 }
 
 #items-notes-menu,
-#items-pdf-menu-a,
+#items-pdf-menu-a1,
+#items-pdf-menu-a2,
 #items-pdf-menu-b {
     box-shadow: 1px 1px 3px rgba(0,0,0,0.33)
 }


### PR DESCRIPTION
 - side menu -> Item: provide separate view and download links for each
of the Supplementary Files.

- side menu -> Files: make the icons for PDF attachment a link to open
(rather than download) them. This behaviour is consistent with the
icons for movies/audio attachments, which play them in-browser

- side menu -> PDF: link to all 3 viewing other options (download,
default browser viewer, i-librarian viewer). A user may want quick
access to any of these, and there’s no benefit to hiding one of them.