### PR TITLE
Fix bug in ordering by date added

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -138,7 +138,7 @@ function perform_search($sql) {
 
     if ($orderby == 'id') {
         $result = $dbHandle->query("SELECT id,file,authors,title,journal,secondary_title,year,volume,pages,abstract,uid,doi,url,addition_date,rating,bibtex
-            FROM library WHERE id IN (SELECT itemID FROM history.`$table_name_hash` ORDER BY id DESC LIMIT $limit OFFSET $from) ORDER BY id DESC");
+            FROM library WHERE id IN (SELECT itemID FROM history.`$table_name_hash` ORDER BY itemID DESC LIMIT $limit OFFSET $from) ORDER BY id DESC");
     } else {
 
         $result = $dbHandle->query("SELECT id,file,authors,title,journal,secondary_title,year,volume,pages,abstract,uid,doi,url,addition_date,rating,bibtex


### PR DESCRIPTION
To ensure results are sorted by date added, it is necessary to filter
based on the itemID field (which contains the actual ID of items),
rather than the id field (which depends on the order in which items
were listed by the database).