### PR TITLE
local admin authentication in LDAP environment

### DIFF
--- a/authenticate.php
+++ b/authenticate.php
@@ -183,7 +183,7 @@ if (isset($_POST['form']) && $_POST['form'] == 'signin' && !empty($_POST['user']
     $username_quoted = $dbHandle->quote($username);
 
     // LDAP authentication.
-    if ($ldap_active) {
+    if (($ldap_active) && ($username != 'admin')) {
         // Verify if ldap was enabled within php.
         if ($ldap_libcheck = function_exists("ldap_connect")) {
             // "LDAP CONNECT function is available.";


### PR DESCRIPTION
Enable admin user to authenticate locally while all other user authenticate through LDAP. This was useful in our case, maybe useful for others as well.