### PR TITLE
BibTex export bug fixed

### DIFF
--- a/export.php
+++ b/export.php
@@ -539,19 +539,19 @@ if (!empty($_GET['export_files']) && isset($_GET['export'])) {
             }
 
             if ($item['reference_type'] == 'conference' || $item['reference_type'] == 'chapter') {
-                unset($bibtex_translation['journal = ']);
+                unset($bibtex_translation['journal   = ']);
                 $bibtex_translation['booktitle = '] = 'secondary_title';
             } elseif ($item['reference_type'] == 'book') {
-                unset($bibtex_translation['journal = ']);
+                unset($bibtex_translation['journal   = ']);
                 $bibtex_translation['series    = '] = 'secondary_title';
             } elseif ($item['reference_type'] == 'thesis') {
-                unset($bibtex_translation['journal = ']);
+                unset($bibtex_translation['journal   = ']);
                 $bibtex_translation['school    = '] = 'secondary_title';
             } elseif ($item['reference_type'] == 'manual') {
-                unset($bibtex_translation['journal = ']);
+                unset($bibtex_translation['journal   = ']);
                 $bibtex_translation['section   = '] = 'secondary_title';
             } elseif ($item['reference_type'] == 'patent') {
-                unset($bibtex_translation['journal = ']);
+                unset($bibtex_translation['journal   = ']);
                 $bibtex_translation['source    = '] = 'secondary_title';
             }
 


### PR DESCRIPTION
The $bibtex_translation entry for the name of the journal gets named "journal<3x space>= " in line 455. But until now the script tries for other text types like "chapter"s of a book or a "thesis" to delete the entry "journal<1x space>= " with two spaces missing. Therefore this text types still have a "journal" entry in the bibtex file and the correct entry for bibtex (booktitle or school) is missing.