### PR TITLE
LDAP binddn fix for OpenLDAP

### DIFF
--- a/authenticate.php
+++ b/authenticate.php
@@ -296,11 +296,11 @@ if (isset($_POST['form']) && $_POST['form'] == 'signin' && !empty($_POST['user']
 
         if (!empty($ldap_binduser_dn)) {
             // Verify the given password
-            $ldap_sr_all_user_attributes = @ldap_search($ldap_connect, '', $ldap_filter_string);
+            $ldap_sr_all_user_attributes = @ldap_search($ldap_connect, $ldap_basedn, $ldap_filter_string);
             $usersattributes = @ldap_get_entries($ldap_connect, $ldap_sr_all_user_attributes);
             // try to connect to ldap using the given attribute and the password
-            if (!$ldap_bind_check_pass = ldap_bind($ldap_connect, $usersattributes[0][$ldap_userlogin_attr][0], $password)) {
-                sendError("Failed to authenticate: " . $usersattributes[0][$ldap_userlogin_attr][0]);
+            if (!$ldap_bind_check_pass = ldap_bind($ldap_connect, is_array($usersattributes[0][$ldap_userlogin_attr]) ? $usersattributes[0][$ldap_userlogin_attr][0] : $usersattributes[0][$ldap_userlogin_attr], $password)) {
+                sendError("Failed to authenticate: " . $usersattributes[0][$ldap_username_attr][0]);
             } else {
                 // password is valid!
             }

--- a/ilibrarian-default.ini
+++ b/ilibrarian-default.ini
@@ -140,7 +140,7 @@ ldap_username_attr = "uid"
 ; Additional Active Directory Settings
 ;ldap_username_attr = "sAMAccountName"
 
-ldap_userlogin_attr = "uid"
+ldap_userlogin_attr = "dn"
 ; Additional Active Directory Settings
 ; attribute which is used to verify login/password pair
 ; ldap_userlogin_attr = "userprincipalname"


### PR DESCRIPTION
There was a mistake when using LDAP groups and bind user.
The basedn was missing in the last LDAP search and the password check did not use the full DN but only the uid attribute. The fix permits both options. Additionaly, the error message was corrected to the user id. Now the login works.